### PR TITLE
Handle graphql errors

### DIFF
--- a/py2graphql/core.py
+++ b/py2graphql/core.py
@@ -93,9 +93,19 @@ class Query(object):
             'query': graphql
         }
         r = requests.post(client.url, json.dumps(body), headers=client.headers)
+
         if r.status_code != 200:
             raise Exception(r.content)
-        return addict.Dict(json.loads(r.content)['data'])
+
+        response_content = json.loads(r.content)
+        data = response_content['data']
+        errors = response_content.get('errors')
+
+        result_dict = addict.Dict(data)
+        if errors is not None:
+            result_dict.update(_errors=errors)
+
+        return result_dict
 
 
 class Client(object):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     ],
     keywords='development',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires=['addict'],
+    install_requires=['addict', 'requests'],
     package_data={},
     data_files=[],
     entry_points={},


### PR DESCRIPTION
Closes #1 

* Store errors returned by GraphQL in the result dictionary with the key `_errors`
* Add `requests` requirement