### PR TITLE
Handle cases where other number types and booleans are passed in

### DIFF
--- a/py2graphql/core.py
+++ b/py2graphql/core.py
@@ -1,3 +1,5 @@
+import numbers
+
 import addict
 import json
 import requests
@@ -39,7 +41,9 @@ class Query(object):
             nl = '\n'
 
         def serialize_arg(arg):
-            if isinstance(arg, int):
+            if isinstance(arg, bool):
+                return 'true' if arg else 'false'
+            elif isinstance(arg, numbers.Number):
                 return str(arg)
             else:
                 return '"{0}"'.format(arg)


### PR DESCRIPTION
> The root of the numeric hierarchy. If you just want to check if an argument x is a number, without caring what kind, use isinstance(x, Number).

https://docs.python.org/3.6/library/numbers.html#numbers.Number